### PR TITLE
Link Guidy brand name to guidy.au

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -12,7 +12,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <div class="prose">
       <p>
         I'm a Danish technologist living on the Sunshine Coast in Queensland, Australia, and the
-        founder of <strong>Guidy</strong> — an end-to-end companion for everyday Australian first
+        founder of <strong class="text-text-primary font-semibold"><a href="https://guidy.au">Guidy</a></strong> — an end-to-end companion for everyday Australian first
         home buyers. They want real guidance and they go looking for it, yet the traditional model
         serves them last, because they take the most time.
       </p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,7 +19,7 @@ const articles = (await getCollection('articles', ({ data }) => !data.draft))
         Building things that matter.
       </h1>
       <p class="font-body text-[17px] text-text-secondary leading-relaxed max-w-[540px] mb-6">
-        Founder of <strong class="text-text-primary font-semibold">Guidy</strong> — an end-to-end companion for everyday Australian first home buyers, built to be the knowledgeable presence they don't otherwise have. It builds on more than two decades in technology, from hands-on engineering through to CIO and CTO leadership across financial services.
+        Founder of <strong class="text-text-primary font-semibold"><a href="https://guidy.au">Guidy</a></strong> — an end-to-end companion for everyday Australian first home buyers, built to be the knowledgeable presence they don't otherwise have. It builds on more than two decades in technology, from hands-on engineering through to CIO and CTO leadership across financial services.
       </p>
       <a href="/about" class="inline-flex items-center gap-1.5 font-body text-accent font-medium no-underline hover:opacity-70 transition-opacity">
         More about me


### PR DESCRIPTION
Links the **Guidy** brand name to https://guidy.au in the homepage hero bio and the About page intro.

Small follow-up to the home/about restructure (#7) — just turns the bolded brand name into a link in both places. Opens in the same tab; `href` is properly quoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)