### PR TITLE
Publish AI article and align Guidy link styling on about page

### DIFF
--- a/src/content/articles/ai-practical-value-beyond-the-hype.md
+++ b/src/content/articles/ai-practical-value-beyond-the-hype.md
@@ -4,7 +4,7 @@ title: "AI's Practical Value Beyond the Hype"
 pubDate: "2026-06-09"
 date: "Jun 2026"
 category: "Opinion"
-readTime: "8 min"
+readTime: "11 min"
 featured: true
 draft: false
 tags: ["ai", "productivity", "agents", "opinion"]

--- a/src/content/articles/ai-practical-value-beyond-the-hype.md
+++ b/src/content/articles/ai-practical-value-beyond-the-hype.md
@@ -5,11 +5,9 @@ pubDate: "2026-06-09"
 date: "Jun 2026"
 category: "Opinion"
 readTime: "8 min"
-featured: false
-draft: true
+featured: true
+draft: false
 tags: ["ai", "productivity", "agents", "opinion"]
-heroImage: "../../assets/articles/2_bell_curve.png"
-heroImageAlt: "20-60-20 bell curve"
 ---
 
 ## The 20/60/20 Problem

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -12,7 +12,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <div class="prose">
       <p>
         I'm a Danish technologist living on the Sunshine Coast in Queensland, Australia, and the
-        founder of <strong class="text-text-primary font-semibold"><a href="https://guidy.au">Guidy</a></strong> — an end-to-end companion for everyday Australian first
+        founder of <strong class="text-text-primary font-semibold"><a href="https://guidy.au" class="!text-text-primary !no-underline">Guidy</a></strong> — an end-to-end companion for everyday Australian first
         home buyers. They want real guidance and they go looking for it, yet the traditional model
         serves them last, because they take the most time.
       </p>


### PR DESCRIPTION
## Summary
- Publish **"AI: Practical Value Beyond the Hype"** — flips `draft: false` and `featured: true` (also drops the unused hero image fields). It now builds as a static route and surfaces in the homepage Writing list.
- Fix the **Guidy link styling on the about page** so it matches the home page. Both pages had identical markup, but the about-page link lives inside `.prose`, whose `a` rule applied an orange color (`#B45309`) and an underline. Added `!text-text-primary !no-underline` to that anchor so it renders bold, primary-color, no underline — same as the home page.

## Verification
- `npm run build` passes; article route is generated.
- Confirmed in the built CSS/HTML that the `!important` utilities override `.prose a` (color → `#1A1918`, no underline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)