### PR TITLE
Lengthen default meta description for social sharing

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -12,7 +12,7 @@ interface Props {
 
 const {
   title = "Jakob Højgaard",
-  description = "Founder, builder, writer. Thoughts on fintech, engineering, and leadership.",
+  description = "Danish technologist and founder of Guidy. Two decades in tech, from hands-on engineering to CIO and CTO leadership — writing on technology, AI, and leadership.",
   image,
   type = 'website',
   publishedTime,


### PR DESCRIPTION
## Summary

Follow-up to #10, addressing the LinkedIn Post Inspector feedback.

The site-wide default meta description was 74 chars; LinkedIn warns under 100. Rewrote it (now **159 chars**, within Google's display limit) around **technology, AI, and leadership**. It flows into `description`, `og:description`, `twitter:description`, and the `WebSite` JSON-LD.

### Canonical host — handled in Vercel, not code
The Inspector also showed the og:image falling back to a stale `licdn.com` image. Cause: metadata points at the apex (`jakobhojgaard.com`) but the site was served on **www**, so the og:image fetch hit a 307 redirect that LinkedIn doesn't follow.

Decision: make the **bare apex the primary domain in Vercel** (so `www` redirects to the apex), matching the apex that the code already uses. That's a Vercel dashboard change — no code needed — so `site` stays `https://jakobhojgaard.com`. This PR is therefore just the description fix.

### Verification
`npm run build` passes; description renders at 159 chars and all canonical/og/sitemap URLs remain on the apex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)