### PR TITLE
Cache-bust og:image and add image dimensions

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -20,7 +20,12 @@ const {
 
 const siteName = "Jakob Højgaard";
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
-const ogImageURL = new URL(image ?? '/og-default.png', Astro.site);
+// Bump the version when the default card changes — gives scrapers (LinkedIn caches
+// resized images on its CDN for ~7 days) a fresh URL so they re-fetch.
+const OG_IMAGE_VERSION = '2';
+const usingDefaultImage = !image;
+const ogImageURL = new URL(image ?? `/og-default.png?v=${OG_IMAGE_VERSION}`, Astro.site);
+const ogImageAlt = usingDefaultImage ? "Jakob Højgaard — Founder & Technologist" : title;
 
 // Person entity — the core of "who is Jakob Højgaard" for search and answer engines.
 const person = {
@@ -87,6 +92,10 @@ const jsonLd =
     <meta property="og:url" content={canonicalURL} />
     <meta property="og:site_name" content={siteName} />
     <meta property="og:image" content={ogImageURL} />
+    <meta property="og:image:alt" content={ogImageAlt} />
+    {usingDefaultImage && <meta property="og:image:type" content="image/png" />}
+    {usingDefaultImage && <meta property="og:image:width" content="1200" />}
+    {usingDefaultImage && <meta property="og:image:height" content="630" />}
     <meta property="og:locale" content="en_US" />
     {publishedTime && <meta property="article:published_time" content={publishedTime} />}
 
@@ -95,6 +104,7 @@ const jsonLd =
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImageURL} />
+    <meta name="twitter:image:alt" content={ogImageAlt} />
     <meta name="twitter:creator" content="@hgaard" />
 
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />


### PR DESCRIPTION
## Summary

After the canonical-host fix, the live page metadata is fully correct (`og:type=website`, `og:image` → apex `200`), but the LinkedIn Post Inspector still showed an old `media.licdn.com` thumbnail. LinkedIn caches the **resized image on its own CDN, keyed to the image URL, for ~7 days** — and this URL was previously used in a published LinkedIn article (`articleshare` in the cached URL), making it extra sticky.

### Changes
- **Versioned default og:image** (`/og-default.png?v=2`) — a new URL that LinkedIn/Slack/X can't match against their cache, forcing a re-fetch. Bump `OG_IMAGE_VERSION` whenever the card art changes.
- **Image metadata** — added `og:image:width` (1200), `og:image:height` (630), `og:image:type`, and `og`/`twitter:image:alt`. Width/height are only emitted for the default card; article pages with their own hero image skip them (correct, since those dimensions differ).

### Verification
`npm run build` passes; confirmed the home page and the article page emit `?v=2` plus the dimension/alt tags, and that an article using its own hero image would not get the fixed 1200×630.

After deploy, re-run the LinkedIn Post Inspector — the `?v=2` URL should pull the headshot card fresh. (The stale `Type: Article` is the same cache and clears on the same re-scrape; live `og:type` is already `website`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)