### PR TITLE
Publish "Introducing Guidy" article

### DIFF
--- a/src/content/articles/introducing-guidy.md
+++ b/src/content/articles/introducing-guidy.md
@@ -1,0 +1,21 @@
+---
+title: "Introducing Guidy"
+excerpt: "I've been in startup mode working on a product for first home buyers. Now I can finally give a sneak peek and open the waitlist."
+pubDate: "2026-07-05"
+date: "Jul 2026"
+category: "Startups"
+readTime: "2 min"
+featured: false
+draft: false
+tags: ["startups", "fintech", "guidy", "first-home-buyers"]
+---
+
+I've got a real soft spot for building things that are genuinely useful, and lately I've been in startup mode working on a product for first home buyers. Now I can finally give a sneak peek and open the waitlist → [guidy.au](https://guidy.au)
+
+Buying your first home is one of the biggest decisions you'll ever make, and one of the most overwhelming and confusing. Oddly, no one's really in your corner for all of it. Lenders build the loan products. Brokers find the loan. Agents sell the house. Everyone owns their piece, but no one helps you make sense of the whole journey, from "where do I even start?" to keys in hand.
+
+That's the gap I want to fill with Guidy. A conversational guide that helps first home buyers understand where they stand, explore their options, and uncover the support they might be eligible for, in plain English, any time of day. And it doesn't stop at guidance. When you're ready, Guidy takes you all the way through to arranging the loan itself.
+
+We can't fix housing affordability on our own. But we can make the path to a first home a whole lot clearer. That's our mission.
+
+Curious? Come along for the ride → [guidy.au](https://guidy.au)


### PR DESCRIPTION
## Summary
- Adds a new article announcing Guidy (guidy.au) and opening the waitlist
- Frontmatter follows existing conventions: category "Startups", dated 2026-07-05, 2 min read, published (not draft)
- Both guidy.au mentions link to https://guidy.au

## Verification
- Full `astro build` passes; page generates at `/articles/introducing-guidy/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)